### PR TITLE
Implement flight service CRUD

### DIFF
--- a/server/pkg/flights/handler/flight_handler.go
+++ b/server/pkg/flights/handler/flight_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/Siya360/take-flight/server/pkg/common"
 	"github.com/Siya360/take-flight/server/pkg/flights/model"
 	"github.com/Siya360/take-flight/server/pkg/flights/service"
 	"github.com/labstack/echo/v4"
@@ -30,4 +31,46 @@ func (h *FlightHandler) SearchFlights(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, flights)
+}
+
+func (h *FlightHandler) GetFlight(c echo.Context) error {
+	id := c.Param("id")
+	flight, err := h.flightService.GetFlight(c.Request().Context(), id)
+	if err != nil {
+		return common.RespondWithError(c, err)
+	}
+	return common.RespondWithSuccess(c, flight)
+}
+
+func (h *FlightHandler) CreateFlight(c echo.Context) error {
+	var flight model.Flight
+	if err := common.ParseJSON(c, &flight); err != nil {
+		return err
+	}
+	created, err := h.flightService.CreateFlight(c.Request().Context(), &flight)
+	if err != nil {
+		return common.RespondWithError(c, err)
+	}
+	return common.RespondWithSuccess(c, created)
+}
+
+func (h *FlightHandler) UpdateFlight(c echo.Context) error {
+	id := c.Param("id")
+	var flight model.Flight
+	if err := common.ParseJSON(c, &flight); err != nil {
+		return err
+	}
+	updated, err := h.flightService.UpdateFlight(c.Request().Context(), id, &flight)
+	if err != nil {
+		return common.RespondWithError(c, err)
+	}
+	return common.RespondWithSuccess(c, updated)
+}
+
+func (h *FlightHandler) DeleteFlight(c echo.Context) error {
+	id := c.Param("id")
+	if err := h.flightService.DeleteFlight(c.Request().Context(), id); err != nil {
+		return common.RespondWithError(c, err)
+	}
+	return common.RespondWithSuccess(c, map[string]string{"message": "Flight successfully deleted"})
 }

--- a/server/pkg/flights/service/flight_service.go
+++ b/server/pkg/flights/service/flight_service.go
@@ -2,13 +2,19 @@ package service
 
 import (
 	"context"
+	"net/http"
+	"time"
 
+	"github.com/Siya360/take-flight/server/pkg/common"
 	"github.com/Siya360/take-flight/server/pkg/flights/model"
+	"github.com/google/uuid"
 )
 
 type FlightRepository interface {
 	Create(ctx context.Context, flight *model.Flight) error
 	FindByID(ctx context.Context, id string) (*model.Flight, error)
+	Update(ctx context.Context, flight *model.Flight) error
+	Delete(ctx context.Context, id string) error
 	Search(ctx context.Context, criteria model.SearchFlightRequest) ([]*model.Flight, error)
 	UpdateSeats(ctx context.Context, flightID string, seats int) error
 }
@@ -27,4 +33,61 @@ func (s *FlightService) SearchFlights(ctx context.Context, criteria model.Search
 
 func (s *FlightService) GetFlight(ctx context.Context, id string) (*model.Flight, error) {
 	return s.repo.FindByID(ctx, id)
+}
+
+func (s *FlightService) CreateFlight(ctx context.Context, flight *model.Flight) (*model.Flight, error) {
+	if flight.ID == "" {
+		flight.ID = uuid.NewString()
+	}
+	now := time.Now()
+	if flight.CreatedAt.IsZero() {
+		flight.CreatedAt = now
+	}
+	flight.UpdatedAt = now
+
+	if err := s.repo.Create(ctx, flight); err != nil {
+		return nil, common.NewAppError(common.ErrInternalServer, "Failed to create flight", http.StatusInternalServerError)
+	}
+	return flight, nil
+}
+
+func (s *FlightService) UpdateFlight(ctx context.Context, id string, flight *model.Flight) (*model.Flight, error) {
+	existing, err := s.repo.FindByID(ctx, id)
+	if err != nil || existing == nil {
+		return nil, common.NewAppError(common.ErrNotFound, "Flight not found", http.StatusNotFound)
+	}
+
+	flight.ID = id
+	flight.CreatedAt = existing.CreatedAt
+	flight.UpdatedAt = time.Now()
+
+	if err := s.repo.Update(ctx, flight); err != nil {
+		return nil, common.NewAppError(common.ErrInternalServer, "Failed to update flight", http.StatusInternalServerError)
+	}
+	return flight, nil
+}
+
+func (s *FlightService) UpdateSeats(ctx context.Context, flightID string, passengerChange int) error {
+	flight, err := s.repo.FindByID(ctx, flightID)
+	if err != nil || flight == nil {
+		return common.NewAppError(common.ErrNotFound, "Flight not found", http.StatusNotFound)
+	}
+
+	newSeats := flight.AvailableSeats - passengerChange
+	if newSeats < 0 {
+		return common.NewAppError(common.ErrInvalidInput, "Insufficient available seats", http.StatusBadRequest)
+	}
+
+	return s.repo.UpdateSeats(ctx, flightID, newSeats)
+}
+
+func (s *FlightService) DeleteFlight(ctx context.Context, id string) error {
+	_, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return common.NewAppError(common.ErrNotFound, "Flight not found", http.StatusNotFound)
+	}
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return common.NewAppError(common.ErrInternalServer, "Failed to delete flight", http.StatusInternalServerError)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- add missing flight repository methods to interface
- implement Create, Update, UpdateSeats, and Delete logic in flight service
- extend flight handler with endpoints to manage flights

## Testing
- `go build ./...` *(fails: undefined authservice.Config, JWTConfig; too many args to NewFlightService)*
- `go test ./...` *(fails: undefined authservice.Config in server.go)*

------
https://chatgpt.com/codex/tasks/task_e_68756060892483338668e90e4ac22b55