### PR TITLE
Fix CORS max age header

### DIFF
--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -4,6 +4,7 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -63,7 +64,7 @@ func CORS(config *CORSConfig) echo.MiddlewareFunc {
 			res.Header().Set("Access-Control-Allow-Origin", allowOrigins)
 			res.Header().Set("Access-Control-Allow-Methods", allowMethods)
 			res.Header().Set("Access-Control-Allow-Headers", allowHeaders)
-			res.Header().Set("Access-Control-Max-Age", string(maxAge))
+			res.Header().Set("Access-Control-Max-Age", strconv.Itoa(maxAge))
 
 			if config.AllowCredentials {
 				res.Header().Set("Access-Control-Allow-Credentials", "true")


### PR DESCRIPTION
## Summary
- use `strconv.Itoa()` when setting the `Access-Control-Max-Age` header so it is formatted correctly

## Testing
- `npm test` *(fails: jest not found)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_68756affd3088333a955d724817234d0