### PR TITLE
Add documentation for Go server setup and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
 # take-flight
 
-This repository hosts a Go based API server.
+Take Flight is a proof-of-concept flight booking API written in Go. The project exposes a REST interface for authentication, booking flights and basic administration tasks.
+
+## Requirements
+
+- Go 1.22+
+- MongoDB and Redis instances (local installations are fine for development)
+
+## Setup
+
+See [server/docs/setup.md](server/docs/setup.md) for full instructions. In short:
+
+```bash
+# get dependencies
+cd server
+go mod download
+
+# adjust configuration
+cp configs/app.yaml configs/app.local.yaml  # edit values as needed
+```
 
 ## Building
 
-Ensure [Go](https://go.dev/doc/install) 1.22 or newer is available.
-Run the following from the `server` directory to compile the API binary:
+Compile the API binary from the `server` directory:
 
 ```bash
 cd server
@@ -14,15 +31,48 @@ go build -o bin/take-flight ./cmd/api
 
 ## Running
 
-After building you can start the server with:
+Run the server with your configuration file:
 
 ```bash
 ./bin/take-flight --config configs/app.yaml
 ```
 
-Or run directly with `go run`:
+You can also run it directly via `go run`:
 
 ```bash
 cd server
 go run ./cmd/api --config configs/app.yaml
 ```
+
+## Configuration
+
+The file `server/configs/app.yaml` contains all runtime settings. Below is an example configuration:
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+mongodb:
+  uri: mongodb://localhost:27017
+  database: takeflight
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 0
+jwt:
+  secret: example-secret
+  expireHours: 24
+  refreshSecret: example-refresh-secret
+  refreshTTL: 168h
+```
+
+## Contribution Guidelines
+
+Contributions are welcome! Please open an issue before submitting a pull request so we can discuss the change. When contributing:
+
+1. Ensure `go vet ./...` and `go build ./cmd/api` run without errors.
+2. Format Go code with `gofmt`.
+3. Update or add tests where appropriate.
+4. Document any new features in `server/docs`.
+

--- a/server/configs/app.yaml
+++ b/server/configs/app.yaml
@@ -1,0 +1,16 @@
+server:
+  host: 0.0.0.0
+  port: 8080
+mongodb:
+  uri: mongodb://localhost:27017
+  database: takeflight
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 0
+jwt:
+  secret: example-secret
+  expireHours: 24
+  refreshSecret: example-refresh-secret
+  refreshTTL: 168h

--- a/server/docs/api.md
+++ b/server/docs/api.md
@@ -1,0 +1,59 @@
+# API Overview
+
+The server exposes a RESTful API under the `/api` prefix. Below is a summary of the main routes.
+
+## Authentication
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/api/auth/login` | Authenticate a user and return JWT tokens. |
+| `POST` | `/api/auth/register` | Create a new user account. |
+| `POST` | `/api/auth/refresh-token` | Obtain a fresh access token using a refresh token. |
+| `POST` | `/api/auth/logout` | Invalidate the current user's token. |
+
+## Users
+
+(Requires authentication)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/users` | List users. Supports `page` and `page_size` query params. |
+| `GET` | `/api/users/:id` | Retrieve a single user. |
+| `PUT` | `/api/users/:id` | Update user information. |
+| `DELETE` | `/api/users/:id` | Delete a user. |
+
+## Flights
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/flights` | Search for flights. |
+| `GET` | `/api/flights/:id` | Get a flight by ID. |
+| `POST` | `/api/flights` | Create a new flight (admin only). |
+| `PUT` | `/api/flights/:id` | Update flight details (admin only). |
+| `DELETE` | `/api/flights/:id` | Delete a flight (admin only). |
+
+## Bookings
+
+(Requires authentication)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/api/bookings` | Create a booking for a flight. |
+| `GET` | `/api/bookings` | Search bookings for the current user. |
+| `GET` | `/api/bookings/:id` | Retrieve booking details. |
+| `PUT` | `/api/bookings/:id` | Update a booking. |
+| `POST` | `/api/bookings/:id/cancel` | Cancel a booking. |
+
+## Admin
+
+(Requires admin role)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/api/admin/dashboard` | Returns high level statistics. |
+| `PUT` | `/api/admin/config` | Update system configuration. |
+| `GET` | `/api/admin/revenue` | Revenue statistics for a date range. |
+| `GET` | `/api/admin/metrics` | System metrics information. |
+| `GET` | `/api/admin/activities` | Recent admin activities. |
+| `PUT` | `/api/admin/notifications` | Update notification settings. |
+

--- a/server/docs/deployment.md
+++ b/server/docs/deployment.md
@@ -1,0 +1,39 @@
+# Deployment
+
+This document describes how to run the compiled server in different environments.
+
+## Local Execution
+
+After building the binary you can run it directly:
+
+```bash
+./bin/take-flight --config configs/app.yaml
+```
+
+The `--config` flag should point to the YAML file that contains your environment specific configuration.
+
+## Docker (optional)
+
+You can also containerise the server. A minimal example using Docker:
+
+```Dockerfile
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY . .
+RUN cd server && go build -o /app/take-flight ./cmd/api
+
+FROM alpine
+COPY --from=build /app/take-flight /usr/local/bin/take-flight
+COPY server/configs/app.yaml /etc/take-flight/app.yaml
+CMD ["take-flight", "--config", "/etc/take-flight/app.yaml"]
+```
+
+Build and run:
+
+```bash
+docker build -t take-flight .
+docker run -p 8080:8080 take-flight
+```
+
+Adjust the configuration volume or environment to suit your deployment.
+

--- a/server/docs/setup.md
+++ b/server/docs/setup.md
@@ -1,0 +1,54 @@
+# Setup
+
+This guide covers the steps required to prepare a development environment for Take Flight.
+
+## Prerequisites
+
+- Go 1.22 or newer
+- MongoDB and Redis servers running locally or accessible in your network
+
+## Installing Dependencies
+
+Clone the repository and fetch dependencies:
+
+```bash
+git clone <repo>
+cd take-flight/server
+go mod download
+```
+
+## Configuration
+
+All runtime settings are stored in `configs/app.yaml`. A sample file is provided:
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+mongodb:
+  uri: mongodb://localhost:27017
+  database: takeflight
+redis:
+  host: localhost
+  port: 6379
+  password: ""
+  db: 0
+jwt:
+  secret: example-secret
+  expireHours: 24
+  refreshSecret: example-refresh-secret
+  refreshTTL: 168h
+```
+
+Adjust the values as needed for your environment. The application expects the file path to be provided via the `--config` flag when starting the server.
+
+## Building the Binary
+
+From the `server` directory run:
+
+```bash
+go build -o bin/take-flight ./cmd/api
+```
+
+Running `go vet ./...` beforehand is a good way to catch potential issues.
+


### PR DESCRIPTION
## Summary
- document project setup, configuration and contribution process in `README.md`
- fill out sample configuration for the Go server
- add setup, deployment and API documentation under `server/docs`

## Testing
- `go vet ./...` *(fails: undefined authservice.Config)*
- `go build ./cmd/api` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68756dd5cb288333ab826535bd718b14