### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,19 @@
+name: Go CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Vet
+        run: go vet ./...
+        working-directory: server
+      - name: Test
+        run: go test ./...
+        working-directory: server

--- a/server/cmd/api/server.go
+++ b/server/cmd/api/server.go
@@ -24,6 +24,7 @@ import (
 	authservice "github.com/Siya360/take-flight/server/pkg/auth/service"
 	bookingmongo "github.com/Siya360/take-flight/server/pkg/bookings/repository/mongodb"
 	bookingservice "github.com/Siya360/take-flight/server/pkg/bookings/service"
+	"github.com/Siya360/take-flight/server/pkg/common"
 	flightmongo "github.com/Siya360/take-flight/server/pkg/flights/repository/mongodb"
 	flightservice "github.com/Siya360/take-flight/server/pkg/flights/service"
 	usermongo "github.com/Siya360/take-flight/server/pkg/users/repository/mongodb"
@@ -154,8 +155,8 @@ func (app *Application) setupServer() error {
 	adminRepo := adminmongo.NewMongoAdminRepository(db)
 
 	// Create auth service config
-	authConfig := &authservice.Config{
-		JWT: authservice.JWTConfig{
+	authConfig := &common.Config{
+		JWT: common.JWTConfig{
 			Secret:        app.config.JWT.Secret,
 			ExpireHours:   app.config.JWT.ExpireHours,
 			RefreshSecret: app.config.JWT.RefreshSecret,
@@ -165,7 +166,7 @@ func (app *Application) setupServer() error {
 	// Initialize services
 	authService := authservice.NewAuthService(authConfig, authRepo, app.cacheClient)
 	userService := userservice.NewUserService(userRepo)
-	flightService := flightservice.NewFlightService(flightRepo, app.cacheClient)
+	flightService := flightservice.NewFlightService(flightRepo)
 	bookingService := bookingservice.NewBookingService(bookingRepo, flightService, app.cacheClient)
 	adminService := adminservice.NewAdminService(adminRepo, adminRepo, app.cacheClient)
 

--- a/server/pkg/flights/handler/flight_handler_test.go
+++ b/server/pkg/flights/handler/flight_handler_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/Siya360/take-flight/server/pkg/flights/model"
+	"github.com/Siya360/take-flight/server/pkg/flights/service"
+)
+
+type mockFlightRepo struct {
+	searchCalled bool
+	searchArg    model.SearchFlightRequest
+}
+
+func (m *mockFlightRepo) Create(ctx context.Context, flight *model.Flight) error { return nil }
+func (m *mockFlightRepo) FindByID(ctx context.Context, id string) (*model.Flight, error) {
+	return nil, nil
+}
+func (m *mockFlightRepo) Update(ctx context.Context, flight *model.Flight) error { return nil }
+func (m *mockFlightRepo) Delete(ctx context.Context, id string) error            { return nil }
+func (m *mockFlightRepo) Search(ctx context.Context, criteria model.SearchFlightRequest) ([]*model.Flight, error) {
+	m.searchCalled = true
+	m.searchArg = criteria
+	return []*model.Flight{{ID: "1", DepartureCity: criteria.DepartureCity}}, nil
+}
+func (m *mockFlightRepo) UpdateSeats(ctx context.Context, id string, seats int) error { return nil }
+
+func TestSearchFlights(t *testing.T) {
+	repo := &mockFlightRepo{}
+	svc := service.NewFlightService(repo)
+	h := NewFlightHandler(svc)
+
+	e := echo.New()
+	reqData := model.SearchFlightRequest{
+		DepartureCity: "A",
+		ArrivalCity:   "B",
+		DepartureDate: time.Now(),
+		Passengers:    1,
+	}
+	body, _ := json.Marshal(reqData)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.SearchFlights(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 got %d", rec.Code)
+	}
+	if !repo.searchCalled {
+		t.Fatal("expected search to be called")
+	}
+	if repo.searchArg.DepartureCity != "A" {
+		t.Fatalf("unexpected criteria: %+v", repo.searchArg)
+	}
+}

--- a/server/pkg/flights/service/flight_service_test.go
+++ b/server/pkg/flights/service/flight_service_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Siya360/take-flight/server/pkg/flights/model"
+)
+
+type mockFlightRepo struct {
+	createFunc      func(ctx context.Context, flight *model.Flight) error
+	findByIDFunc    func(ctx context.Context, id string) (*model.Flight, error)
+	updateFunc      func(ctx context.Context, flight *model.Flight) error
+	deleteFunc      func(ctx context.Context, id string) error
+	searchFunc      func(ctx context.Context, criteria model.SearchFlightRequest) ([]*model.Flight, error)
+	updateSeatsFunc func(ctx context.Context, id string, seats int) error
+}
+
+func (m *mockFlightRepo) Create(ctx context.Context, flight *model.Flight) error {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, flight)
+	}
+	return nil
+}
+
+func (m *mockFlightRepo) FindByID(ctx context.Context, id string) (*model.Flight, error) {
+	if m.findByIDFunc != nil {
+		return m.findByIDFunc(ctx, id)
+	}
+	return nil, nil
+}
+
+func (m *mockFlightRepo) Update(ctx context.Context, flight *model.Flight) error {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, flight)
+	}
+	return nil
+}
+
+func (m *mockFlightRepo) Delete(ctx context.Context, id string) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockFlightRepo) Search(ctx context.Context, criteria model.SearchFlightRequest) ([]*model.Flight, error) {
+	if m.searchFunc != nil {
+		return m.searchFunc(ctx, criteria)
+	}
+	return nil, nil
+}
+
+func (m *mockFlightRepo) UpdateSeats(ctx context.Context, id string, seats int) error {
+	if m.updateSeatsFunc != nil {
+		return m.updateSeatsFunc(ctx, id, seats)
+	}
+	return nil
+}
+
+func TestCreateFlightSetsID(t *testing.T) {
+	repo := &mockFlightRepo{}
+	svc := NewFlightService(repo)
+	flight := &model.Flight{}
+	if _, err := svc.CreateFlight(context.Background(), flight); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if flight.ID == "" {
+		t.Fatal("expected ID to be set")
+	}
+	if flight.CreatedAt.IsZero() || flight.UpdatedAt.IsZero() {
+		t.Fatal("expected timestamps to be set")
+	}
+}
+
+func TestUpdateSeatsInsufficient(t *testing.T) {
+	repo := &mockFlightRepo{
+		findByIDFunc: func(ctx context.Context, id string) (*model.Flight, error) {
+			return &model.Flight{ID: id, AvailableSeats: 1}, nil
+		},
+	}
+	svc := NewFlightService(repo)
+	if err := svc.UpdateSeats(context.Background(), "1", 2); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for flight service and handler
- fix server setup to use common config and adjust NewFlightService call
- run go vet and go test in CI

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876000abdd88333add8e0ec5407ec4c