### PR TITLE
Add Docker build and compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY . .
+RUN cd server && go build -o /app/take-flight ./cmd/api
+
+FROM alpine
+WORKDIR /app
+COPY --from=build /app/take-flight ./take-flight
+COPY server/configs/app.yaml /etc/take-flight/app.yaml
+EXPOSE 8080
+CMD ["/app/take-flight", "--config", "/etc/take-flight/app.yaml"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ cd server
 go run ./cmd/api --config configs/app.yaml
 ```
 
+## Docker
+
+The repository includes a `Dockerfile` and `docker-compose.yml` for a containerised
+setup. Build and run the API along with MongoDB and Redis using:
+
+```bash
+docker compose up --build
+```
+
+The server will be available on [http://localhost:8080](http://localhost:8080).
+
 ## Configuration
 
 The file `server/configs/app.yaml` contains all runtime settings. Below is an example configuration:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  api:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+      - redis
+    volumes:
+      - ./server/configs/app.yaml:/etc/take-flight/app.yaml:ro
+  mongo:
+    image: mongo:6
+    ports:
+      - "27017:27017"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- containerize Go API with Dockerfile
- add docker-compose with Mongo and Redis
- document Docker usage in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876025d34c883339a9fe064bdcfcec7