### PR TITLE
chore: use typed JSON health responses

### DIFF
--- a/services/admin/README.md
+++ b/services/admin/README.md
@@ -8,4 +8,10 @@ Standalone microservice providing administrative APIs for the Take Flight platfo
 go run ./cmd
 ```
 
-The service exposes a `GET /health` endpoint for health checks.
+The service exposes a `GET /health` endpoint returning:
+
+```json
+{"status": "ok"}
+```
+
+for health checks.

--- a/services/admin/cmd/main.go
+++ b/services/admin/cmd/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
 func main() {
 	e := echo.New()
 	e.GET("/health", func(c echo.Context) error {
-		return c.String(200, "OK")
+		return c.JSON(http.StatusOK, healthResponse{Status: "ok"})
 	})
 
 	if err := e.Start(":8080"); err != nil {

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -8,4 +8,10 @@ Standalone microservice providing authentication APIs for the Take Flight platfo
 go run ./cmd
 ```
 
-The service exposes a `GET /health` endpoint for health checks.
+The service exposes a `GET /health` endpoint returning:
+
+```json
+{"status": "ok"}
+```
+
+for health checks.

--- a/services/auth/cmd/main.go
+++ b/services/auth/cmd/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
 func main() {
 	e := echo.New()
 	e.GET("/health", func(c echo.Context) error {
-		return c.String(200, "OK")
+		return c.JSON(http.StatusOK, healthResponse{Status: "ok"})
 	})
 
 	if err := e.Start(":8080"); err != nil {

--- a/services/auth/go.mod
+++ b/services/auth/go.mod
@@ -1,9 +1,6 @@
 module github.com/Siya360/take-flight/services/auth
 
-mkgc9h-codex/review-codebase-for-agentic-ai-migration
 go 1.22
-main
-
 
 require github.com/labstack/echo/v4 v4.11.4
 

--- a/services/bookings/README.md
+++ b/services/bookings/README.md
@@ -8,4 +8,10 @@ Standalone microservice providing booking APIs for the Take Flight platform.
 go run ./cmd
 ```
 
-The service exposes a `GET /health` endpoint for health checks.
+The service exposes a `GET /health` endpoint returning:
+
+```json
+{"status": "ok"}
+```
+
+for health checks.

--- a/services/bookings/cmd/main.go
+++ b/services/bookings/cmd/main.go
@@ -1,19 +1,23 @@
 package main
 
 import (
-    "log"
+	"log"
+	"net/http"
 
-    "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4"
 )
 
-func main() {
-    e := echo.New()
-    e.GET("/health", func(c echo.Context) error {
-        return c.String(200, "OK")
-    })
-
-    if err := e.Start(":8080"); err != nil {
-        log.Fatalf("server error: %v", err)
-    }
+type healthResponse struct {
+	Status string `json:"status"`
 }
 
+func main() {
+	e := echo.New()
+	e.GET("/health", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, healthResponse{Status: "ok"})
+	})
+
+	if err := e.Start(":8080"); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/services/flights/README.md
+++ b/services/flights/README.md
@@ -8,4 +8,10 @@ Standalone microservice providing flight schedule and inventory APIs for the Tak
 go run ./cmd
 ```
 
-The service exposes a `GET /health` endpoint for health checks.
+The service exposes a `GET /health` endpoint returning:
+
+```json
+{"status": "ok"}
+```
+
+for health checks.

--- a/services/flights/cmd/main.go
+++ b/services/flights/cmd/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
 func main() {
 	e := echo.New()
 	e.GET("/health", func(c echo.Context) error {
-		return c.String(200, "OK")
+		return c.JSON(http.StatusOK, healthResponse{Status: "ok"})
 	})
 
 	if err := e.Start(":8080"); err != nil {

--- a/services/users/README.md
+++ b/services/users/README.md
@@ -8,4 +8,10 @@ Standalone microservice providing user management APIs for the Take Flight platf
 go run ./cmd
 ```
 
-The service exposes a `GET /health` endpoint for health checks.
+The service exposes a `GET /health` endpoint returning:
+
+```json
+{"status": "ok"}
+```
+
+for health checks.

--- a/services/users/cmd/main.go
+++ b/services/users/cmd/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"log"
+	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
+type healthResponse struct {
+	Status string `json:"status"`
+}
+
 func main() {
 	e := echo.New()
 	e.GET("/health", func(c echo.Context) error {
-		return c.String(200, "OK")
+		return c.JSON(http.StatusOK, healthResponse{Status: "ok"})
 	})
 
 	if err := e.Start(":8080"); err != nil {


### PR DESCRIPTION
## Summary
- use a typed struct for each service's `/health` response
- document the JSON health payload in service READMEs

## Testing
- `cd services/auth && go vet ./... && go build -o /tmp/auth ./cmd`
- `cd services/users && go vet ./... && go build -o /tmp/users ./cmd`
- `cd services/flights && go vet ./... && go build -o /tmp/flights ./cmd`
- `cd services/bookings && go vet ./... && go build -o /tmp/bookings ./cmd`
- `cd services/admin && go vet ./... && go build -o /tmp/admin ./cmd`


------
https://chatgpt.com/codex/tasks/task_e_689219611d4c8333af2d944fd76909c0