### PR TITLE
feat: add React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@ Take Flight is a full-stack, microservice-based flight management platform. The 
 
 ## Services
 
-| Service       | Language | Directory                 | Default Port |
-|---------------|----------|---------------------------|--------------|
+| Service              | Language | Directory             | Default Port |
+| -------------------- | -------- | --------------------- | ------------ |
 | **Backend Services** |
-| Auth          | Go       | `services/auth`           | 8081         |
-| Users         | Go       | `services/users`          | 8082         |
-| Flights       | Go       | `services/flights`        | 8083         |
-| Bookings      | Go       | `services/bookings`       | 8084         |
-| Admin         | Go       | `services/admin`          | 8085         |
-| Orchestrator  | Python   | `agents/orchestrator`     | 8090         |
-| **Frontend** |
-| Frontend      | React/TS | `frontend/`               | 3000         |
-
+| Auth                 | Go       | `services/auth`       | 8081         |
+| Users                | Go       | `services/users`      | 8082         |
+| Flights              | Go       | `services/flights`    | 8083         |
+| Bookings             | Go       | `services/bookings`   | 8084         |
+| Admin                | Go       | `services/admin`      | 8085         |
+| Orchestrator         | Python   | `agents/orchestrator` | 8090         |
+| **Frontend**         |
+| Frontend             | React/TS | `frontend/`           | 3000         |
 
 Each Go service exposes a `/health` endpoint using Echo. The orchestrator uses FastAPI to host LangChain agents.
 
@@ -73,6 +72,15 @@ yarn build
 
 The frontend uses environment variables to connect to backend services. Copy `frontend/.env.example` to `frontend/.env` and adjust URLs as needed for local development.
 
+### Amadeus API
+
+The flights service fetches live data from the Amadeus API. Obtain credentials from [Amadeus for Developers](https://developers.amadeus.com/) and set them in your environment:
+
+```bash
+export AMADEUS_CLIENT_ID=your_client_id
+export AMADEUS_CLIENT_SECRET=your_client_secret
+```
+
 ## Docker Compose
 
 The repository includes a `docker-compose.yml` that builds all services and supporting dependencies.
@@ -85,18 +93,14 @@ docker compose up --build
 Service endpoints will be available on `localhost` using the ports listed above.
 
 ## Supporting Infrastructure
-main
 
 The compose file also starts supporting services for persistence, caching, and messaging:
 
-
-| Service  | Purpose          | Default Port |
-|----------|------------------|--------------|
-| MongoDB  | Document store   | 27017        |
-| Redis    | Cache            | 6379         |
-| NATS     | Message broker   | 4222         |
-
-main
+| Service | Purpose        | Default Port |
+| ------- | -------------- | ------------ |
+| MongoDB | Document store | 27017        |
+| Redis   | Cache          | 6379         |
+| NATS    | Message broker | 4222         |
 
 ## Contribution Guidelines
 
@@ -106,4 +110,3 @@ Contributions are welcome! Please open an issue before submitting a pull request
 2. Format Go code with `gofmt` and Python code with `black` or `ruff` (future).
 3. Update or add tests where appropriate.
 4. Document any new features in `README.md` or service-specific docs.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
     build: ./services/flights
     ports:
       - "8083:8080"
+    environment:
+      - AMADEUS_CLIENT_ID=${AMADEUS_CLIENT_ID}
+      - AMADEUS_CLIENT_SECRET=${AMADEUS_CLIENT_SECRET}
 
   bookings:
     build: ./services/bookings

--- a/services/flights/.env.example
+++ b/services/flights/.env.example
@@ -1,0 +1,2 @@
+AMADEUS_CLIENT_ID=your_client_id
+AMADEUS_CLIENT_SECRET=your_client_secret

--- a/services/flights/README.md
+++ b/services/flights/README.md
@@ -7,5 +7,18 @@ Standalone microservice providing flight schedule and inventory APIs for the Tak
 ```bash
 go run ./cmd
 ```
-The service exposes a `GET /health` endpoint returning `{ "status": "ok" }` for health checks.
+
+The service exposes:
+
+- `GET /health` returning `{ "status": "ok" }`
+- `GET /flights/search?origin=JFK&destination=LAX&departureDate=2025-09-01` fetching live flight offers from Amadeus
+
+### Configuration
+
+Set Amadeus credentials before running:
+
+```bash
+export AMADEUS_CLIENT_ID=your_client_id
+export AMADEUS_CLIENT_SECRET=your_client_secret
+```
 

--- a/services/flights/cmd/main.go
+++ b/services/flights/cmd/main.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 )
@@ -11,13 +17,99 @@ type healthResponse struct {
 	Status string `json:"status"`
 }
 
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
 func main() {
 	e := echo.New()
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
 
+	e.GET("/flights/search", handleFlightSearch)
+
 	if err := e.Start(":8080"); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+func handleFlightSearch(c echo.Context) error {
+	origin := c.QueryParam("origin")
+	destination := c.QueryParam("destination")
+	departure := c.QueryParam("departureDate")
+	if origin == "" || destination == "" || departure == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "missing params"})
+	}
+
+	clientID := os.Getenv("AMADEUS_CLIENT_ID")
+	clientSecret := os.Getenv("AMADEUS_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "missing Amadeus credentials"})
+	}
+
+	token, err := getToken(clientID, clientSecret)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	data, err := searchFlights(token, origin, destination, departure)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	var parsed interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, parsed)
+}
+
+func getToken(id, secret string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", id)
+	form.Set("client_secret", secret)
+
+	req, err := http.NewRequest(http.MethodPost, "https://test.api.amadeus.com/v1/security/oauth2/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token request failed: %s", b)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return "", err
+	}
+	return tr.AccessToken, nil
+}
+
+func searchFlights(token, origin, dest, date string) ([]byte, error) {
+	endpoint := fmt.Sprintf("https://test.api.amadeus.com/v2/shopping/flight-offers?originLocationCode=%s&destinationLocationCode=%s&departureDate=%s&adults=1", url.QueryEscape(origin), url.QueryEscape(dest), url.QueryEscape(date))
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("flight search failed: %s", b)
+	}
+	return io.ReadAll(resp.Body)
 }


### PR DESCRIPTION
## Summary
- integrate Vite + React frontend under `frontend/`
- wire up frontend service in docker compose with environment variables
- document frontend development and full-stack compose usage
- remove leftover merge text from README
- connect Go flights service to Amadeus API with `/flights/search`
- expose Amadeus credentials via compose and service docs

## Testing
- `go vet ./...` (flights)
- `go build -o /tmp/flights ./cmd`
- `bun install`
- `bun test`
- `bun run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `python -m py_compile agents/orchestrator/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f411cea408333b4bb76652a0206e4